### PR TITLE
AIP-10: removed compress step to shave time of total deployment time

### DIFF
--- a/.github/workflows/deployToAzure.yml
+++ b/.github/workflows/deployToAzure.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: .net-app
-      - name: Compress
-        run: Compress-Archive -Path ./* -DestinationPath ./artifact.zip
-        shell: powershell
+#      - name: Compress
+#        run: Compress-Archive -Path ./* -DestinationPath ./artifact.zip
+#        shell: powershell
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v3
@@ -39,7 +39,5 @@ jobs:
           app-name: ${{ inputs.app-name }}
           slot-name: ${{ inputs.slot-name }}
           publish-profile: ${{ secrets.publish-profile }}
-          package: artifact.zip
-          type: zip
           clean: true
           restart: true


### PR DESCRIPTION
Verwijdering van de compression step waardoor er geen .zip deployed hoeft te worden, dit scheelt in test met u15 workflow ruim 7 minuten op de totale build tijd